### PR TITLE
fix versioning oops

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ publishing {
         maven(MavenPublication) {
             groupId = "org.wilsonwatson"
             artifactId = System.getenv('PATCH') == null ? "nt4wasm" : "nt4wasm_bleeding_edge"
-            version = "0." + (System.getenv('PATCH') == null ? "0" : System.getenv('PATCH'))
+            version = "0.1." + (System.getenv('PATCH') == null ? "0" : System.getenv('PATCH'))
 
             from components.java
         }


### PR DESCRIPTION
Old versioning was x.x, but to facilitate bleeding_edge, it should be x.x.0, where x.x.y is the yth run of bleeding_edge.